### PR TITLE
Update script to work with GitLab 16.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Script that creates Personal Access Token for Gitlab API.
 Formerly published on Github Gist: https://gist.github.com/vitalyisaev2/215f890e75252cd36794221c2debf365
 
 Tested with:
-* Gitlab 13.9.4
+* Gitlab 16.6.0

--- a/personal_access_token.py
+++ b/personal_access_token.py
@@ -2,83 +2,91 @@
 """
 Script that creates Personal Access Token for Gitlab API;
 Tested with:
-- Gitlab Community Edition 10.1.4
-- Gitlab Enterprise Edition 12.6.2
-- Gitlab Enterprise Edition 13.4.4
+- Gitlab Community Edition 16.6.0
 """
-import sys
+import sys, os
 import requests
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from bs4 import BeautifulSoup
+import json
 
-endpoint = "http://localhost:10080"
+# Remove warnings when running against a self signed cert deployment
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+endpoint = os.environ.get("GITLAB_SERVER", "https://localhost:8080")
+login = os.environ.get("GITLAB_USERNAME", "root")
+password = os.environ.get("GITLAB_PASSWORD", "password")
+api_scope = os.environ.get("GITLAB_TOKE_SCOPE", "api")
+
+host_name = urlparse(endpoint).hostname
 root_route = urljoin(endpoint, "/")
 sign_in_route = urljoin(endpoint, "/users/sign_in")
 pat_route = urljoin(endpoint, "/-/profile/personal_access_tokens")
 
-login = "root"
-password = "password"
+headers = {
+    "Host": host_name,
+    "Content-Type": "application/x-www-form-urlencoded"
+}
 
 
 def find_csrf_token(text):
     soup = BeautifulSoup(text, "lxml")
     token = soup.find(attrs={"name": "csrf-token"})
     param = soup.find(attrs={"name": "csrf-param"})
+
     data = {param.get("content"): token.get("content")}
     return data
 
 
 def obtain_csrf_token():
-    r = requests.get(root_route)
+    r = requests.get(root_route, verify=False)
     token = find_csrf_token(r.text)
     return token, r.cookies
-
-
-def obtain_authenticity_token(cookies):
-    r = requests.get(pat_route, cookies=cookies)
-    soup = BeautifulSoup(r.text, "lxml")
-    token = soup.find('input', attrs={'name': 'authenticity_token', 'type': 'hidden'}).get('value')
-    return token
 
 
 def sign_in(csrf, cookies):
     data = {
         "user[login]": login,
         "user[password]": password,
-        "user[remember_me]": 0,
-        "utf8": "✓"
+        "user[remember_me]": 0
     }
     data.update(csrf)
-    r = requests.post(sign_in_route, data=data, cookies=cookies)
+
+    r = requests.post(sign_in_route, headers=headers, cookies=cookies, data=data, verify=False)
+
     token = find_csrf_token(r.text)
     return token, r.history[0].cookies
 
 
-def obtain_personal_access_token(name, expires_at, csrf, cookies, authenticity_token):
-    data = {
-        "personal_access_token[expires_at]": expires_at,
+def obtain_personal_access_token(name, expires_at, csrf, cookies):    
+    query_params = {
         "personal_access_token[name]": name,
-        "personal_access_token[scopes][]": "api",
-        "authenticity_token": authenticity_token,
-        "utf8": "✓"
+        "personal_access_token[expires_at]": expires_at,
+        "personal_access_token[scopes][]": api_scope
     }
-    data.update(csrf)
-    r = requests.post(pat_route, data=data, cookies=cookies)
-    soup = BeautifulSoup(r.text, "lxml")
-    token = soup.find('input', id='created-personal-access-token').get('value')
+
+    headers = {
+        "Host": host_name,
+        "Cookie": f"_gitlab_session={cookies['_gitlab_session']}",
+        "Referer": pat_route,
+        "X-CSRF-Token": csrf
+    }
+
+    r = requests.post(pat_route, headers=headers, params=query_params, verify=False)
+    token = json.loads(r.text)["new_token"]
+
     return token
 
 
 def main():
     csrf1, cookies1 = obtain_csrf_token()
-    print("root", csrf1, cookies1)
     csrf2, cookies2 = sign_in(csrf1, cookies1)
-    print("sign_in", csrf2, cookies2)
-    authenticity_token = obtain_authenticity_token(cookies2)
 
     name = sys.argv[1]
     expires_at = sys.argv[2]
-    token = obtain_personal_access_token(name, expires_at, csrf2, cookies2, authenticity_token)
+
+    token = obtain_personal_access_token(name, expires_at, csrf2['authenticity_token'], cookies2)
     print(token)
 
 

--- a/personal_access_token.py
+++ b/personal_access_token.py
@@ -17,7 +17,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 endpoint = os.environ.get("GITLAB_SERVER", "https://localhost:8080")
 login = os.environ.get("GITLAB_USERNAME", "root")
 password = os.environ.get("GITLAB_PASSWORD", "password")
-api_scope = os.environ.get("GITLAB_TOKE_SCOPE", "api")
+api_scope = os.environ.get("GITLAB_TOKEN_SCOPE", "api")
 
 host_name = urlparse(endpoint).hostname
 root_route = urljoin(endpoint, "/")


### PR DESCRIPTION
### Changes
- Update script to work with GitLab 16.6.0
- Add the ability to configure parameters from env variables
  - GITLAB_SERVER
  - GITLAB_USERNAME
  - GITLAB_PASSWORD
  - GITLAB_TOKEN_SCOPE
- Support for servers with https self signed certificates

---
Tested on Community 16.6.0